### PR TITLE
fix media files not showing in development

### DIFF
--- a/life_tracker_backend/urls.py
+++ b/life_tracker_backend/urls.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -9,3 +11,7 @@ urlpatterns = [
     path("api/notifications/", include("notifications.urls")),
     path("api/tasks/", include("tasks.urls")),
 ]
+
+# Serve media files in development
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This pull request updates the `life_tracker_backend/urls.py` file to enhance the handling of media files during development. The changes ensure that media files are properly served when the application is running in debug mode.

Enhancements to media file handling:

* Imported `settings` and `static` from `django.conf` and `django.conf.urls.static`, respectively, to enable serving media files during development.
* Added a conditional block to append a `static` URL pattern for serving media files when `DEBUG` mode is enabled.