### PR TITLE
Feature/password reset

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -35,3 +35,23 @@ class EmailVerificationToken(models.Model):
     
     def __str__(self):
         return f"Verification token for {self.user.username}"
+
+class PasswordResetToken(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='password_reset_tokens')
+    token = models.UUIDField(default=uuid.uuid4, unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField()
+    is_used = models.BooleanField(default=False)
+    
+    def save(self, *args, **kwargs):
+        if not self.expires_at:
+            # Set token to expire after 1 hour
+            self.expires_at = datetime.now() + timedelta(hours=1)
+        super().save(*args, **kwargs)
+    
+    @property
+    def is_valid(self):
+        return datetime.now() < self.expires_at and not self.is_used
+    
+    def __str__(self):
+        return f"Password reset token for {self.user.username}"

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -37,3 +37,23 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ['id', 'username', 'email', 'first_name', 'last_name', 'profile_picture']
         read_only_fields = ['id']
+
+class PasswordResetRequestSerializer(serializers.Serializer):
+    email = serializers.EmailField(required=True)
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    token = serializers.UUIDField(required=True)
+    password = serializers.CharField(write_only=True, required=True, style={'input_type': 'password'})
+    password2 = serializers.CharField(write_only=True, required=True, style={'input_type': 'password'})
+    
+    def validate(self, data):
+        if data['password'] != data['password2']:
+            raise serializers.ValidationError({"password": "Password fields didn't match."})
+        
+        # Validate password strength
+        try:
+            validate_password(data['password'])
+        except ValidationError as e:
+            raise serializers.ValidationError({"password": list(e)})
+
+        return data

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 from .views import (
     RegisterView, LoginView, UserProfileView, UserListView, api_test_view, 
-    EmailVerificationView, ResendEmailVerificationView
+    EmailVerificationView, ResendEmailVerificationView, PasswordResetRequestView,
+    PasswordResetConfirmView
 )
 from rest_framework_simplejwt.views import TokenRefreshView
 
@@ -13,6 +14,8 @@ urlpatterns = [
     path("all-usernames/", UserListView.as_view(), name="all-usernames"),
     path("verify-email/", EmailVerificationView.as_view(), name="email-verify"),
     path("resend-verification/", ResendEmailVerificationView.as_view(), name="resend-verify"),
+    path("password-reset/", PasswordResetRequestView.as_view(), name="password-reset-request"),
+    path("password-reset/confirm/", PasswordResetConfirmView.as_view(), name="password-reset-confirm"),
     # New URL pattern for the API testing page
     path("test-api/", api_test_view, name="test-api"),
 ]


### PR DESCRIPTION
This pull request introduces a password reset feature to the `users` app, including model, serializer, view, and URL updates to support the functionality. The main changes involve adding a `PasswordResetToken` model, serializers for handling password reset requests and confirmations, and API views for processing these requests. Below is a summary of the most important changes:

### Feature Implementation: Password Reset

* **Password Reset Token Model**:
  - Added `PasswordResetToken` model to store tokens for password reset functionality. Includes fields for user association, token, expiration, and usage status. Implements logic to auto-set expiration to 1 hour and a property to check token validity. (`users/models.py`)

* **Serializers for Password Reset**:
  - Added `PasswordResetRequestSerializer` to validate email input for requesting a password reset.
  - Added `PasswordResetConfirmSerializer` to validate token and new password input, including password confirmation and strength checks. (`users/serializers.py`)

* **Views for Password Reset**:
  - Added `PasswordResetRequestView` to handle password reset requests by generating a token, sending an email with a reset link, and ensuring security by not revealing if the email exists.
  - Added `PasswordResetConfirmView` to handle password reset confirmations by validating the token, resetting the password, and marking the token as used. (`users/views.py`)

### Routing Updates

* **New URL Patterns**:
  - Added routes for password reset request (`password-reset/`) and confirmation (`password-reset/confirm/`) endpoints. (`users/urls.py`)

### Dependency Updates

* **Imports**:
  - Updated imports in `users/views.py` to include the new `PasswordResetToken` model and serializers for password reset functionality. (`users/views.py`)