### PR TITLE
retrive username in notes

### DIFF
--- a/tracker/serializers.py
+++ b/tracker/serializers.py
@@ -3,7 +3,12 @@ from .models import Note
 
 
 class NoteSerializer(serializers.ModelSerializer):
+    user = serializers.SerializerMethodField()
+
     class Meta:
         model = Note
-        fields = ["id", "title", "content", "created_at", "updated_at", "task"]
-        read_only_fields = ["id", "created_at", "updated_at"]
+        fields = ["id", "title", "content", "created_at", "updated_at", "task", "user"]
+        read_only_fields = ["id", "created_at", "updated_at", "user"]
+
+    def get_user(self, obj):
+        return obj.user.username


### PR DESCRIPTION
This pull request introduces enhancements to the `Note` model's serialization and the `notes_list` view to improve user-specific data handling and task-based filtering. The most important changes include adding a `user` field to the `NoteSerializer` and updating the `notes_list` view to support filtering notes by task and enforce task ownership validation.

### Serialization Enhancements:
* [`tracker/serializers.py`](diffhunk://#diff-f7853b9744af3856616afb137f4acb3c8b4fa56fd39decdc9499f6ca6892a9b7R6-R14): Added a `user` field to the `NoteSerializer` to include the username of the note's owner in serialized responses. This field is read-only and uses the `get_user` method to fetch the username.

### View Logic Improvements:
* [`tracker/views.py`](diffhunk://#diff-ab97ad514dbc39ec95cd916cd1606ff3e9ad7907441752d77f518daccfd543d0R10-R32): Updated the `notes_list` view to allow filtering notes by a specific task using the `task` query parameter. This ensures only notes associated with the authenticated user and the specified task are returned.
* [`tracker/views.py`](diffhunk://#diff-ab97ad514dbc39ec95cd916cd1606ff3e9ad7907441752d77f518daccfd543d0R10-R32): Enhanced the `POST` method in the `notes_list` view to validate that the task associated with a new note belongs to the authenticated user, returning a 403 error if the user does not own the task.