### PR TITLE
implement account management features for deactivation and deletion

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -88,3 +88,10 @@ class ChangePasswordSerializer(serializers.Serializer):
         except ValidationError as e:
             raise serializers.ValidationError(list(e))
         return value
+
+class AccountDeactivationSerializer(serializers.Serializer):
+    password = serializers.CharField(required=True, write_only=True, style={'input_type': 'password'})
+    
+class AccountDeletionSerializer(serializers.Serializer):
+    password = serializers.CharField(required=True, write_only=True, style={'input_type': 'password'})
+    confirm_deletion = serializers.BooleanField(required=True)

--- a/users/urls.py
+++ b/users/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from .views import (
     RegisterView, LoginView, UserProfileView, UserListView, api_test_view, 
     EmailVerificationView, ResendEmailVerificationView, PasswordResetRequestView,
-    PasswordResetConfirmView, ChangePasswordView
+    PasswordResetConfirmView, ChangePasswordView, AccountManagementView
 )
 from rest_framework_simplejwt.views import TokenRefreshView
 
@@ -17,6 +17,8 @@ urlpatterns = [
     path("password-reset/", PasswordResetRequestView.as_view(), name="password-reset-request"),
     path("password-reset/confirm/", PasswordResetConfirmView.as_view(), name="password-reset-confirm"),
     path("change-password/", ChangePasswordView.as_view(), name="change-password"),
-    # New URL pattern for the API testing page
-    path("test-api/", api_test_view, name="test-api"),
+    # Change account URL to match frontend expectations
+    path("account/", AccountManagementView.as_view(), name="account-management"),
+    path("deactivate-account/", AccountManagementView.as_view(), {'action': 'deactivate'}, name="deactivate-account"),
+    path("delete-account/", AccountManagementView.as_view(), {'action': 'delete'}, name="delete-account"),
 ]


### PR DESCRIPTION
This pull request introduces functionality for account management, specifically for account deactivation and deletion. It adds serializers, views, and URL patterns to handle these operations. Below are the key changes grouped by theme:

### Account Management Functionality

* Added `AccountDeactivationSerializer` and `AccountDeletionSerializer` to handle input validation for account deactivation and deletion requests. (`users/serializers.py`)
* Introduced `AccountManagementView` to handle account deactivation and deletion logic, including password validation and user authentication. It supports both `POST` and `DELETE` methods for these actions. (`users/views.py`)

### URL Updates

* Updated `users/urls.py` to include new URL patterns for account management, deactivation, and deletion. These endpoints are mapped to `AccountManagementView` with appropriate actions. (`users/urls.py`)

### Serializer and View Integration

* Imported `AccountDeactivationSerializer` and `AccountDeletionSerializer` into `users/views.py` to integrate them with the new `AccountManagementView`. (`users/views.py`)

These changes add robust account management capabilities, improving user control over their accounts.