### PR TITLE
feat(task): add default color field for task events

### DIFF
--- a/tasks/models.py
+++ b/tasks/models.py
@@ -15,6 +15,7 @@ class Task(models.Model):
     end_time = models.TimeField()
     
     category = models.CharField(max_length=100)
+    color = models.CharField(max_length=30, blank=True, null=True, default="#039be5")  # Default blue color for events
     task_icon = models.ImageField(upload_to="task_icons/", blank=True, null=True)
     completed = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
This pull request introduces a new optional `color` field to the `Task` model in `tasks/models.py`. This field allows tasks to have an associated color, with a default value set to `#039be5` (a shade of blue).

Key change:

* [`tasks/models.py`](diffhunk://#diff-64945fde3111e70753b24e4abbd6eb5766440c5077bf035c19a86d4cde59fb32R18): Added a `color` field to the `Task` model. This field is a `CharField` with a maximum length of 30, and it is optional (`blank=True, null=True`). The default value is set to `#039be5`, providing a default blue color for tasks.